### PR TITLE
Fix a typo in a settings property

### DIFF
--- a/octoprint_dropbox_timelapse/__init__.py
+++ b/octoprint_dropbox_timelapse/__init__.py
@@ -14,7 +14,7 @@ class DropboxTimelapsePlugin(octoprint.plugin.SettingsPlugin,
     def get_settings_defaults(self):
         return dict(
             api_token=None,
-            delete_afer_upload=False
+            delete_after_upload=False
         )
 
     def get_settings_restricted_paths(self):


### PR DESCRIPTION
Spotted this when I took a final look prior to merging. Thought you might want to have it fixed since it probably causes issues with the delete-after-upload feature.