### PR TITLE
Added New Trigger Event - OctoLapse

### DIFF
--- a/octoprint_dropbox_timelapse/__init__.py
+++ b/octoprint_dropbox_timelapse/__init__.py
@@ -55,7 +55,11 @@ class DropboxTimelapsePlugin(octoprint.plugin.SettingsPlugin,
 
     def on_event(self, event, payload):
         from octoprint.events import Events
-        if event == Events.MOVIE_DONE:
+        acceptable_timelapse_events = (
+            Events.MOVIE_DONE,
+            Events.PLUGIN_OCTOLAPSE_MOVIE_DONE
+        )
+        if any(event == acceptable_event for acceptable_event in acceptable_timelapse_events):
             self.upload_timelapse(payload)
 
     def upload_timelapse(self, payload):

--- a/octoprint_dropbox_timelapse/__init__.py
+++ b/octoprint_dropbox_timelapse/__init__.py
@@ -55,12 +55,10 @@ class DropboxTimelapsePlugin(octoprint.plugin.SettingsPlugin,
 
     def on_event(self, event, payload):
         from octoprint.events import Events
-        try:
-            if event = Events.PLUGIN_OCTOLAPSE_MOVIE_DONE:
-                self.upload_timelapse(payload)
-        except:
-            if event = Events.MOVIE_DONE:
-                self.upload_timelapse(payload)
+        if hasattr(Events, 'PLUGIN_OCTOLAPSE_MOVIE_DONE') and event == Events.PLUGIN_OCTOLAPSE_MOVIE_DONE:
+            self.upload_timelapse(payload)
+        elif event == Events.MOVIE_DONE:
+            self.upload_timelapse(payload)
 
     def upload_timelapse(self, payload):
         path = payload['movie']

--- a/octoprint_dropbox_timelapse/__init__.py
+++ b/octoprint_dropbox_timelapse/__init__.py
@@ -55,12 +55,12 @@ class DropboxTimelapsePlugin(octoprint.plugin.SettingsPlugin,
 
     def on_event(self, event, payload):
         from octoprint.events import Events
-        acceptable_timelapse_events = (
-            Events.MOVIE_DONE,
-            Events.PLUGIN_OCTOLAPSE_MOVIE_DONE
-        )
-        if any(event == acceptable_event for acceptable_event in acceptable_timelapse_events):
-            self.upload_timelapse(payload)
+        try:
+            if event = Events.PLUGIN_OCTOLAPSE_MOVIE_DONE:
+                self.upload_timelapse(payload)
+        except:
+            if event = Events.MOVIE_DONE:
+                self.upload_timelapse(payload)
 
     def upload_timelapse(self, payload):
         path = payload['movie']

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ plugin_version = "0.1.2"
 plugin_description = """Automatically upload rendered timelapses to Dropbox. Can also delete after upload to save space on the Raspberry Pi SD Card."""
 
 # The plugin's author. Can be overwritten within OctoPrint's internal data via __plugin_author__ in the plugin module
-plugin_author = "Justin Slay"
+plugin_author = "Justin Slay, Sam Kemp"
 
 # The plugin's author's mail address.
 plugin_author_email = "justin.slay@gmail.com"


### PR DESCRIPTION
Addresses #7 

Needs testing to understand what happens when OctoLapse is not present. 
Might also be able to be simplified to `if event in acceptable_timelapse_events`, need to check OctoPrint Plugin Documentation. 