### PR TITLE
Update version to 0.1.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_dropbox_timelapse"
 plugin_name = "OctoPrint-Dropbox-Timelapse"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.2"
+plugin_version = "0.1.4"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
The version bump from 0.1.2 to 0.1.3 was missed. Jumping to 0.1.4 to
force clients to update properly.

Fixes #11 